### PR TITLE
Require the interface dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "homepage": "https://github.com/joomla-framework/controller",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10"
+        "php": ">=5.3.10",
+        "joomla/application": "~1.0",
+        "joomla/input": "~1.0"
     },
     "require-dev": {
         "joomla/application": "~1.0",
@@ -14,10 +16,6 @@
         "joomla/test": "~1.0",
         "phpunit/phpunit": "4.*",
         "squizlabs/php_codesniffer": "1.*"
-    },
-    "suggest": {
-        "joomla/application": "~1.0",
-        "joomla/input": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -9,7 +9,7 @@
 namespace Joomla\Controller;
 
 use Joomla\Input\Input;
-use Joomla\Application;
+use Joomla\Application\AbstractApplication;
 
 /**
  * Joomla Framework Base Controller Class
@@ -21,7 +21,7 @@ abstract class AbstractController implements ControllerInterface
 	/**
 	 * The application object.
 	 *
-	 * @var    Application\AbstractApplication
+	 * @var    AbstractApplication
 	 * @since  1.0
 	 */
 	private $app;
@@ -37,12 +37,12 @@ abstract class AbstractController implements ControllerInterface
 	/**
 	 * Instantiate the controller.
 	 *
-	 * @param   Input                            $input  The input object.
-	 * @param   Application\AbstractApplication  $app    The application object.
+	 * @param   Input                $input  The input object.
+	 * @param   AbstractApplication  $app    The application object.
 	 *
 	 * @since  1.0
 	 */
-	public function __construct(Input $input = null, Application\AbstractApplication $app = null)
+	public function __construct(Input $input = null, AbstractApplication $app = null)
 	{
 		$this->input = $input;
 		$this->app = $app;
@@ -51,7 +51,7 @@ abstract class AbstractController implements ControllerInterface
 	/**
 	 * Get the application object.
 	 *
-	 * @return  Application\AbstractApplication  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException if the application has not been set.
@@ -99,13 +99,13 @@ abstract class AbstractController implements ControllerInterface
 	/**
 	 * Set the application object.
 	 *
-	 * @param   Application\AbstractApplication  $app  The application object.
+	 * @param   AbstractApplication  $app  The application object.
 	 *
 	 * @return  AbstractController  Returns itself to support chaining.
 	 *
 	 * @since   1.0
 	 */
-	public function setApplication(Application\AbstractApplication $app)
+	public function setApplication(AbstractApplication $app)
 	{
 		$this->app = $app;
 

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -8,8 +8,8 @@
 
 namespace Joomla\Controller;
 
-use Joomla\Application;
-use Joomla\Input;
+use Joomla\Application\AbstractApplication;
+use Joomla\Input\Input;
 
 /**
  * Joomla Framework Controller Interface
@@ -34,7 +34,7 @@ interface ControllerInterface extends \Serializable
 	/**
 	 * Get the application object.
 	 *
-	 * @return  Application\AbstractApplication  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   1.0
 	 */
@@ -43,7 +43,7 @@ interface ControllerInterface extends \Serializable
 	/**
 	 * Get the input object.
 	 *
-	 * @return  Input\Input  The input object.
+	 * @return  Input  The input object.
 	 *
 	 * @since   1.0
 	 */
@@ -52,22 +52,22 @@ interface ControllerInterface extends \Serializable
 	/**
 	 * Set the application object.
 	 *
-	 * @param   Application\AbstractApplication  $app  The application object.
+	 * @param   AbstractApplication  $app  The application object.
 	 *
 	 * @return  ControllerInterface  Returns itself to support chaining.
 	 *
 	 * @since   1.0
 	 */
-	public function setApplication(Application\AbstractApplication $app);
+	public function setApplication(AbstractApplication $app);
 
 	/**
 	 * Set the input object.
 	 *
-	 * @param   Input\Input  $input  The input object.
+	 * @param   Input  $input  The input object.
 	 *
 	 * @return  ControllerInterface  Returns itself to support chaining.
 	 *
 	 * @since   1.0
 	 */
-	public function setInput(Input\Input $input);
+	public function setInput(Input $input);
 }


### PR DESCRIPTION
The ControllerInterface typehints and explicitly requires the Application and Input packages.  This moves them into the require section instead of being only suggestions.