### PR TITLE
Decouple app and input from interface, bump to PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ env:
 
 matrix:
   include:
-    - php: 5.3
-    - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.4
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.5
     - php: 5.6
       env: RUN_PHPCS="yes"

--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,25 @@
     "homepage": "https://github.com/joomla-framework/controller",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10|>=7.0",
-        "joomla/application": "~1.0",
-        "joomla/input": "~1.0"
+        "php": ">=5.4|>=7.0"
     },
     "require-dev": {
+        "joomla/application": "~1.0",
+        "joomla/input": "~1.0",
         "phpunit/phpunit": "~4.8|~5.0",
         "squizlabs/php_codesniffer": "1.*"
     },
+    "suggest": {
+        "joomla/application": "The joomla/application package is required to use Joomla\\Controller\\AbstractController",
+        "joomla/input": "The joomla/input package is required to use Joomla\\Controller\\AbstractController"
+    },
     "autoload": {
         "psr-4": {
-            "Joomla\\Controller\\": "src/",
+            "Joomla\\Controller\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Joomla\\Controller\\Tests\\": "Tests/"
         }
     },

--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -45,7 +45,7 @@ abstract class AbstractController implements ControllerInterface
 	public function __construct(Input $input = null, AbstractApplication $app = null)
 	{
 		$this->input = $input;
-		$this->app = $app;
+		$this->app   = $app;
 	}
 
 	/**

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -30,44 +30,4 @@ interface ControllerInterface extends \Serializable
 	 * @throws  \RuntimeException
 	 */
 	public function execute();
-
-	/**
-	 * Get the application object.
-	 *
-	 * @return  AbstractApplication  The application object.
-	 *
-	 * @since   1.0
-	 */
-	public function getApplication();
-
-	/**
-	 * Get the input object.
-	 *
-	 * @return  Input  The input object.
-	 *
-	 * @since   1.0
-	 */
-	public function getInput();
-
-	/**
-	 * Set the application object.
-	 *
-	 * @param   AbstractApplication  $app  The application object.
-	 *
-	 * @return  ControllerInterface  Returns itself to support chaining.
-	 *
-	 * @since   1.0
-	 */
-	public function setApplication(AbstractApplication $app);
-
-	/**
-	 * Set the input object.
-	 *
-	 * @param   Input  $input  The input object.
-	 *
-	 * @return  ControllerInterface  Returns itself to support chaining.
-	 *
-	 * @since   1.0
-	 */
-	public function setInput(Input $input);
 }


### PR DESCRIPTION
Remove the interface requirement for the application and input packages.  Bump to PHP 5.4 as is being done with other packages.